### PR TITLE
changes for public presentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # DiligentSearchWebsite
 
-This repository holds the Diligentsearch project
+This repository holds the Diligentsearch project. Further project information can be found on http://diligentsearch.eu/
+
 The project is based on the 'outofcopyright' project
 
 ## Objectives:
 
-Allow a end user to determine the copyrigh status of an orphan work in the European Union
+Allow a end user to determine the orphan works status of a possibly copyright protected work in the European Union
 
 ## Data model of application:
 

--- a/app/editor.html
+++ b/app/editor.html
@@ -45,7 +45,7 @@
 	<div style="text-align:center">
 		<h1>Editor Development Template</h1>
 		<p>
-			The objective is to provide functionalities of the OutOfCOpyright project and additionnal features such as block of questions, free text, links, etc...
+			The objective is to provide functionalities of the Dilligent Search project and additionnal features such as block of questions, free text, links, etc...
 		</p>
 	</div>
 

--- a/app/index.html
+++ b/app/index.html
@@ -25,7 +25,7 @@
 
 <body>
 
-
+	<h1>State of development of tools for diligentsearch.eu</h1>
 	<a href="./editor.html">
 		<h3>Editor development template</h3>
 		<p>Work in progress</p>

--- a/app/readme-config.md
+++ b/app/readme-config.md
@@ -1,4 +1,4 @@
-OutOfCopyright Configuration
+Diligent search Configuration
 ==========
 
 


### PR DESCRIPTION
Our funders are not the same as the OutOfCopyright Funders, as such they want to see their own name in a presentation. 

Can we change these mentions to outofcopryight.eu to diligentsearch.eu